### PR TITLE
Replace deprecated boolean package with copy of function from source v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
       "ts-node/register/transpile-only"
     ]
   },
-  "dependencies": {
-    "boolean": "^3.1.4"
-  },
+  "dependencies": {},
   "description": "Fast and spec-compliant printf implementation for Node.js and browser.",
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -1,0 +1,22 @@
+/**
+ * Copy function from deprecated `boolean` npm package v3.2.0 to avoid breaking changes.
+ *
+ * @see https://www.npmjs.com/package/boolean?activeTab=code
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- any from source `boolean` package v3.2.0
+export const boolean = function (value: any): boolean {
+  switch (Object.prototype.toString.call(value)) {
+    case '[object String]':
+      return ['true', 't', 'yes', 'y', 'on', '1'].includes(
+        value.trim().toLowerCase(),
+      );
+    case '[object Number]':
+      return value.valueOf() === 1;
+
+    case '[object Boolean]':
+      return value.valueOf();
+
+    default:
+      return false;
+  }
+};

--- a/src/createPrintf.ts
+++ b/src/createPrintf.ts
@@ -13,12 +13,12 @@ import type {
 type FormatUnboundExpression = (
   subject: string,
   token: PlaceholderToken,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional per @gajus
   boundValues: any[],
 ) => string;
 
 const formatDefaultUnboundExpression = (
-  // @ts-expect-error unused parameter
-  subject: string,
+  _subject: string,
   token: PlaceholderToken,
 ): string => {
   return token.placeholder;
@@ -31,6 +31,7 @@ type Configuration = {
 type Printf = (subject: string, ...boundValues: any[]) => string;
 
 export const createPrintf = (configuration?: Configuration): Printf => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- intentional per @gajus
   const padValue = (value: string, width: number, flag: Flag | null): string => {
     if (flag === '-') {
       return value.padEnd(width, ' ');

--- a/src/createPrintf.ts
+++ b/src/createPrintf.ts
@@ -1,6 +1,6 @@
 import {
   boolean,
-} from 'boolean';
+} from './boolean';
 import {
   tokenize,
 } from './tokenize';

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -43,6 +43,7 @@ export const tokenize = (subject: string): Token[] => {
     } else if (matchResult.groups) {
       lastToken = {
         conversion: matchResult.groups.conversion,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional per @gajus
         flag: matchResult.groups.flag as any || null,
         placeholder: match,
         position: matchResult.groups.position ? Number.parseInt(matchResult.groups.position, 10) - 1 : argumentIndex++,


### PR DESCRIPTION
Fixes #11

The `boolean()` function itself could use a modernization refactor however in this PR it is kept 1:1 with original dependency v3.2.0 to preserve functionality. Tests pass.

Source obtained from npm:
https://www.npmjs.com/package/boolean?activeTab=code
